### PR TITLE
chore: correção no arquivo visualizador.py

### DIFF
--- a/visualizador.py
+++ b/visualizador.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
+import os
 from typing import List, Tuple
 
 def visualizar_labirinto(grid: List[List[int]], caminho: List[Tuple[int, int]] = []):
@@ -8,16 +9,32 @@ def visualizar_labirinto(grid: List[List[int]], caminho: List[Tuple[int, int]] =
     grid: A grade do labirinto.
     caminho: Lista de posições representando o caminho
     """
+    # Verifica se existe o diretorio.
+    if not os.path.exists('resultados_img'):
+        os.makedirs('resultados_img')  # Mesma coisa que "mkdir resultados_img"
+
+    count = len([f for f in os.listdir('resultados_img') if f.endswith('.png')]) # faz a contagem de quantos arquivos com final .png existe para implementar na proxima contagem
+
     plt.figure(figsize=(10, 10))
     plt.imshow(grid, cmap='binary')
-    
+
     if caminho:
         caminho = np.array(caminho)
+
         plt.plot(caminho[:, 1], caminho[:, 0], 'b-', linewidth=3, label='Caminho')
+        plt.scatter(caminho[:, 1], caminho[:, 0], color='gray', s=50, zorder=5, label='Passos')
         plt.plot(caminho[0, 1], caminho[0, 0], 'go', markersize=15, label='Início')
         plt.plot(caminho[-1, 1], caminho[-1, 0], 'ro', markersize=15, label='Objetivo')
-    
+
+    #texto bottom
+    total_passos = len(caminho)
+    plt.subplots_adjust(bottom=0.15)
+    plt.figtext(0.5, 0.05, f"Total de passos realizados até chegar ao objetivo: {total_passos}",
+                horizontalalignment='center', verticalalignment='center', fontsize=14)
+
     plt.grid(True)
     plt.legend(fontsize=12)
     plt.title("Resultado da Busca A* no Labirinto")
-    plt.show()
+
+    plt.savefig(f"resultados_img/labirinto_{count + 1}_image.png")
+    plt.close()


### PR DESCRIPTION
Ao executar o arquivo `principal.py`, encontrei o seguinte erro:

![Erro Matplotlib](https://github.com/user-attachments/assets/ee7672f5-eb8c-4138-ae78-4d613b37b7df)

```plaintext
UserWarning: Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.
plt.show()
```
Este erro ocorre porque o Matplotlib está configurado para usar o backend agg, que não suporta interface gráfica, impedindo a exibição de gráficos com o comando plt.show(). Pesquisando, descobri que esse problema é comum em ambientes WSL (Windows Subsystem for Linux), devido à ausência de um servidor gráfico por padrão.

Encontrei uma discussão no Reddit com possíveis soluções: [Reddit - Erro Matplotlib](https://www.reddit.com/r/learnpython/comments/16tzyr3/error_message_matplotlib_is_currently_using_agg/?rdt=39388).

**Solução Implementada**
Como solução paliativa, substitui o uso do plt.show() por plt.savefig(). Agora, o gráfico é salvo em um diretório como imagem e pode ser visualizado diretamente, contornando o erro no meu ambiente WSL.

**Alteração feita**
Agora, ao executar o principal.py, ele irá gerar um diretório chamado resultados_img, e dentro dele serão geradas as imagens do labirinto de forma sequencial. Para visualizá-las, basta clicar na imagem."